### PR TITLE
Sidebar Navigation: Arrow should point to the right when collapsed

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -146,6 +146,7 @@ const LinkList = styled(List)`
 
 const CollapseMenuItem = styled(MenuItemButton)`
   display: none;
+  transform: ${({ isCollapsed }) => (isCollapsed ? "rotate(180deg)" : "")};
 
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;


### PR DESCRIPTION
- rotate CollapseMenuItem icon when the sidebar is collapsed so it points to the right